### PR TITLE
Add hooks for ESLint and Stylelint. Update Rubocop hook

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,117 @@
+---
+AllCops:
+  DisabledByDefault: true
+  Exclude:
+    - bin/**/*
+    - node_modules/**/*
+    - db/migrate/*
+    - db/schema.rb
+  TargetRubyVersion: 2.5
+Layout/AccessModifierIndentation:
+  EnforcedStyle: indent
+Layout/BlockAlignment:
+  EnforcedStyleAlignWith: either
+Layout/DefEndAlignment:
+  EnforcedStyleAlignWith: start_of_line
+Layout/DotPosition:
+  EnforcedStyle: leading
+Layout/EmptyComment:
+  Enabled: true
+Layout/EmptyLineBetweenDefs:
+  Enabled: true
+  NumberOfEmptyLines: 1
+Layout/EmptyLinesAroundBlockBody:
+  EnforcedStyle: no_empty_lines
+Layout/EmptyLinesAroundClassBody:
+  EnforcedStyle: no_empty_lines
+Layout/EmptyLinesAroundModuleBody:
+  EnforcedStyle: no_empty_lines
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: start_of_line
+Layout/ExtraSpacing:
+  AllowForAlignment: true
+Layout/IndentArray:
+  EnforcedStyle: consistent
+Layout/IndentHash:
+  EnforcedStyle: consistent
+Layout/IndentationConsistency:
+  EnforcedStyle: normal
+Layout/IndentationWidth:
+  Width: 2
+Layout/SpaceAroundBlockParameters:
+  EnforcedStyleInsidePipes: no_space
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: space
+Layout/SpaceAroundOperators:
+  Enabled: true
+Layout/SpaceBeforeBlockBraces:
+  EnforcedStyle: space
+Layout/SpaceInLambdaLiteral:
+  EnforcedStyle: require_no_space
+Layout/SpaceInsideBlockBraces:
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: no_space
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: no_space
+Layout/SpaceInsideReferenceBrackets:
+  EnforcedStyle: no_space
+Layout/SpaceInsideStringInterpolation:
+  EnforcedStyle: no_space
+Layout/Tab:
+  Enabled: true
+Layout/TrailingWhitespace:
+  Enabled: true
+Lint/SafeNavigationChain:
+  Enabled: true
+Lint/ShadowedArgument:
+  Enabled: true
+Lint/UnusedBlockArgument:
+  Enabled: true
+Lint/UnusedMethodArgument:
+  Enabled: true
+Naming/VariableName:
+  EnforcedStyle: snake_case
+Rails/LexicallyScopedActionFilter:
+  Include:
+    - app/controllers/**/*.rb
+Rails/TimeZone:
+  EnforcedStyle: flexible
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - test
+    - production
+Style/BlockDelimiters:
+  EnforcedStyle: line_count_based
+Style/BracesAroundHashParameters:
+  EnforcedStyle: no_braces
+Style/EmptyElse:
+  EnforcedStyle: both
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+Style/HashSyntax:
+  EnforcedStyle: ruby19_no_mixed_keys
+Style/MethodDefParentheses:
+  EnforcedStyle: require_parentheses
+Style/NumericLiterals:
+  MinDigits: 5
+  Strict: false
+Style/RedundantReturn:
+  Enabled: true
+Style/Semicolon:
+  Enabled: true
+Style/SingleLineMethods:
+  Enabled: true
+Style/StabbyLambdaParentheses:
+  EnforcedStyle: require_parentheses
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: single_quotes
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: no_comma
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: no_comma
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: no_comma

--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ And then execute:
 Execute the generator command to copy the files:
 
     $ bundle exec rails generate able_git_hooks:install
+
+
+For the ESLint default configuration you'll need to install
+
+- eslint-plugin-import
+- eslint-plugin-react
+- eslint-plugin-prettier

--- a/lib/able_git_hooks/generators/install_generator.rb
+++ b/lib/able_git_hooks/generators/install_generator.rb
@@ -4,6 +4,9 @@ module AbleGitHooks
       desc "Install git hook files"
       source_root File.expand_path("../templates", __FILE__)
 
+      class_option :with_stylelint, type: :boolean, default: false, description: "Include the default configuration for stylelint"
+
+
       def install_git_hooks
         copy_file "_do_hook", ".git/hooks/_do_hook"
         chmod ".git/hooks/_do_hook", 0755
@@ -21,6 +24,32 @@ module AbleGitHooks
 
       def copy_rubocop_defaults
         template "rubocop.yml", "config/rubocop.yml"
+      end
+
+      def install_eslint_hooks
+        copy_file "eslint-check.js", "hooks/pre-commit/eslint-check.js"
+        chmod "hooks/pre-commit/eslint-check.js", 0755
+      end
+
+      def copy_eslint_defaults
+        copy_file "eslintrc.json", ".eslintrc.json"
+      end
+
+      def copy_prettier_defaults
+        copy_file "prettierrc", ".prettierrc"
+      end
+
+      def install_stylelint_hooks
+        if options["with_stylelint"]
+          copy_file "stylelint-check.js", "hooks/pre-commit/stylelint-check.js"
+          chmod "hooks/pre-commit/stylelint-check.js", 0755
+        end
+      end
+
+      def copy_stylelint_defaults
+        if options["with_stylelint"]
+          copy_file "stylelintrc", ".stylelintrc"
+        end
       end
     end
   end

--- a/lib/able_git_hooks/generators/templates/_do_hook
+++ b/lib/able_git_hooks/generators/templates/_do_hook
@@ -14,5 +14,5 @@ declare -r hookdir="hooks/$ARG0"
 
 for hook in "$hookdir"/*; do
   echo "executing hook: ${hook}"
-  exec "${hook}"
+  eval "${hook}"
 done

--- a/lib/able_git_hooks/generators/templates/eslint-check.js
+++ b/lib/able_git_hooks/generators/templates/eslint-check.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+"use strict";
+
+/***
+ * Description:
+ *    Run prettier on the files are they are staged to be commit. Exit successfully
+ * only if the file would be left unchanged by prettier.
+ *
+ * Steps:
+ *
+ *  1. List the sources files that are to be committed.
+ *  2. Use git show :<path> to print the staged file to stdout.
+ *  3. Pipe stdout to `prettier.check`.
+ *
+ ***/
+
+const { promisify } = require("util");
+let { exec } = require("child_process");
+exec = promisify(exec);
+const ESLintCLIEngine = require("eslint").CLIEngine;
+const cli = new ESLintCLIEngine({});
+const formatter = cli.getFormatter();
+
+
+const getStagedFiles =
+  "git diff --staged --name-only -z --diff-filter=ACMR";
+
+const onlyJSFiles = filenames => {
+  return filenames.filter(
+    file => file.endsWith(".js") || file.endsWith(".jsx"),
+  );
+};
+
+const splitFileNames = ret => {
+  const fileNames = ret.stdout.substring(0, ret.stdout.length - 1);
+  return fileNames.split("\u0000");
+};
+
+function and(x, y) {
+  return x && y;
+}
+
+const reduceWithAnd = xs => {
+  return xs.reduce(and, true);
+};
+
+const exit = success => {
+  if (success) {
+    process.exit(0);
+  } else {
+    process.exit(1);
+  }
+};
+
+function lintFile(filepath) {
+  return exec(`git show :${filepath}`).then(ret => {
+    const report = cli.executeOnText(ret.stdout, filepath);
+    if (report.errorCount > 0 || report.warningCount > 0) {
+      const errorResults = ESLintCLIEngine.getErrorResults(report.results);
+      console.log(formatter(errorResults));
+    }
+    return report.errorCount === 0 && report.warningCount === 0;
+  });
+}
+
+function lintFiles(filepaths) {
+  return Promise.all(filepaths.map(lintFile));
+}
+
+exec(getStagedFiles)
+  .then(splitFileNames)
+  .then(onlyJSFiles)
+  .then(lintFiles)
+  .then(reduceWithAnd)
+  .then(exit);

--- a/lib/able_git_hooks/generators/templates/eslintrc.json
+++ b/lib/able_git_hooks/generators/templates/eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  plugins: ["import", "react", "prettier"],
+  "rules": {
+    "no-dupe-keys": "error",
+    "no-undef": "error",
+    "no-unreachable": "error",
+    "no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    "no-useless-constructor": "error",
+    "no-var": "error",
+    "no-duplicate-imports": "error",
+    "no-duplicate-case": "error",
+    "no-console": "error",
+    "no-debugger": "error",
+    "import/no-unresolved": "error",
+    "import/default": "error",
+    "react/jsx-no-undef": "error",
+    "react/jsx-uses-vars": 1,
+    "react/jsx-uses-react": "error",
+    "react/react-in-jsx-scope": "error",
+    "react/no-string-refs": "error",
+    "react/prop-types": ["error", { skipUndeclared: true }],
+    "react/forbid-prop-types": "error",
+    "react/prefer-stateless-function": "error",
+    "prettier/prettier": "error"
+  }
+}

--- a/lib/able_git_hooks/generators/templates/prettierrc
+++ b/lib/able_git_hooks/generators/templates/prettierrc
@@ -1,0 +1,3 @@
+{
+  "trailingComma": "all"
+}

--- a/lib/able_git_hooks/generators/templates/rubocop.rb
+++ b/lib/able_git_hooks/generators/templates/rubocop.rb
@@ -4,6 +4,9 @@ require "rubocop"
 require "shellwords"
 
 staged_files = `git diff -z --staged --name-only --diff-filter=ACM`.split("\u0000")
+
+exit 0 if staged_files.empty?
+
 config_store = RuboCop::ConfigStore.new
 target_files = RuboCop::TargetFinder.new(config_store).find(staged_files)
 

--- a/lib/able_git_hooks/generators/templates/stylelint-check.js
+++ b/lib/able_git_hooks/generators/templates/stylelint-check.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/***
+ * Description:
+ *   Run stylelint against the staged version of style files. If any errors are
+ * found by stylelint, print them to standard output and return with a non-zero
+ * exit code. Otherwise return successfully.
+***/
+
+const { promisify } = require('util');
+let { exec } = require('child_process');
+exec = promisify(exec);
+const stylelint = require('stylelint');
+
+
+const getStagedFiles =
+  "git diff --staged --name-only -z --diff-filter=ACMR";
+
+const onlyJSFiles = filenames => {
+  return filenames.filter(
+    file => file.endsWith(".js") || file.endsWith(".jsx"),
+  );
+};
+
+const splitFileNames = ret => {
+  const fileNames = ret.stdout.substring(0, ret.stdout.length - 1);
+  return fileNames.split("\u0000");
+};
+
+function and(x, y) {
+  return x && y;
+}
+
+const reduceWithAnd = xs => {
+  return xs.reduce(and, true);
+};
+
+const exit = success => {
+  if (success) {
+    process.exit(0);
+  } else {
+    process.exit(1);
+  }
+};
+
+function lintFile(filepath) {
+  return exec(`git show :${filepath}`)
+    .then(ret => stylelint.lint({ code: ret.stdout, codeFilename: filepath, formatter: 'verbose' }))
+    .then(result => {
+      if (!result.errored) {
+        return true;
+      } else {
+        console.log(result.output);
+        return false;
+      }
+    });
+}
+
+function lintFiles(filepaths) {
+  return Promise.all(filepaths.map(lintFile));
+}
+
+exec(getStagedFiles)
+  .then(splitFileNames)
+  .then(onlyStyleFiles)
+  .then(lintFiles)
+  .then(reduceWithAnd)
+  .then(exit);

--- a/lib/able_git_hooks/generators/templates/stylelintrc
+++ b/lib/able_git_hooks/generators/templates/stylelintrc
@@ -1,0 +1,15 @@
+{
+  "processors": ["stylelint-processor-styled-components"],
+  "extends": [
+    "stylelint-config-standard",
+    "stylelint-config-styled-components"
+  ],
+  "syntax": "scss",
+  "plugins": ["stylelint-order"],
+  "rules": {
+    "order/properties-alphabetical-order": true,
+    "block-opening-brace-space-after": null,
+    "block-closing-brace-space-before": null,
+    "color-hex-case": "lower"
+  }
+}

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -7,14 +7,16 @@ class InstallGeneratorTest < Rails::Generators::TestCase
 
   DESTINATION = File.expand_path File.join(File.dirname(__FILE__), "..", "..", "tmp")
 
-  FileUtils.mkdir_p(DESTINATION) unless Dir.exist?(DESTINATION)
-
   destination DESTINATION
   tests       AbleGitHooks::Generators::InstallGenerator
 
   def setup
     remake_dirs ".git", "hooks", "config"
     run_generator
+  end
+
+  def teardown
+    rm_r DESTINATION
   end
 
   def test_rubocop_hooks_were_copied
@@ -52,6 +54,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   private
 
   def remake_dirs(*dirs)
+    FileUtils.mkdir_p(DESTINATION) unless Dir.exist?(DESTINATION)
     dirs.each do |dir|
       path = "#{DESTINATION}/#{dir}"
 

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -35,6 +35,22 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_eslint_hook_were_copied
+    assert_file "hooks/pre-commit/eslint-check.js"
+  end
+
+  def test_eslint_config_was_copied
+    assert_file ".eslintrc.json"
+  end
+
+  def test_stylelint_hook_not_copied
+    assert_no_file "hooks/pre-commit/stylelint-check.js"
+  end
+
+  def test_stylelint_config_not_copied
+    assert_no_file ".stylelintrc"
+  end
+
   private
 
   def remake_dirs(*dirs)

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -18,9 +18,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_rubocop_hooks_were_copied
-    assert_file "hooks/pre-commit/rubocop" do |f|
-      assert_match(/bundle exec rubocop/, f)
-    end
+    assert_file "hooks/pre-commit/rubocop.rb"
   end
 
   def test_git_hook_was_copied

--- a/test/generators/install_generator_with_stylelint_test.rb
+++ b/test/generators/install_generator_with_stylelint_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+require "rails/generators/test_case"
+require "able_git_hooks/generators/install_generator"
+
+class InstallGeneratorWithStylelintTest < Rails::Generators::TestCase
+  include FileUtils
+
+  DESTINATION = File.expand_path File.join(File.dirname(__FILE__), "..", "..", "tmp")
+
+  destination DESTINATION
+  tests AbleGitHooks::Generators::InstallGenerator
+
+  def setup
+    remake_dirs ".git", "hooks", "config"
+    run_generator %w(--with-stylelint)
+  end
+
+  def teardown
+    rm_r DESTINATION
+  end
+
+  def test_stylelint_hook_not_copied
+    assert_file "hooks/pre-commit/stylelint-check.js"
+  end
+
+  def test_stylelint_config_not_copied
+    assert_file ".stylelintrc"
+  end
+
+  private
+
+  def remake_dirs(*dirs)
+    FileUtils.mkdir_p(DESTINATION) unless Dir.exist?(DESTINATION)
+    dirs.each do |dir|
+      path = "#{DESTINATION}/#{dir}"
+
+      rm_r path if Dir.exist?(path)
+      mkdir_p path
+    end
+  end
+end


### PR DESCRIPTION
1. Fix for when running 
2. Add a hook for ESLint and for Stylelint.

There are other variations of git hooks. One running sass through prettier, another one running prettier as a stand-alone.